### PR TITLE
erofs-utils:Fix memory leak of asprintf function

### DIFF
--- a/lib/inode.c
+++ b/lib/inode.c
@@ -788,7 +788,7 @@ int erofs_droid_inode_fsconfig(struct erofs_inode *inode,
 		fspath = erofs_fspath(path);
 	} else {
 		if (asprintf(&decorated, "%s/%s", cfg.mount_point,
-			     erofs_fspath(path)) <= 0)
+			     erofs_fspath(path)) < 0)
 			return -ENOMEM;
 		fspath = decorated;
 	}

--- a/lib/xattr.c
+++ b/lib/xattr.c
@@ -217,7 +217,7 @@ static struct xattr_item *erofs_get_selabel_xattr(const char *srcpath,
 		else
 #endif
 			ret = asprintf(&fspath, "/%s", erofs_fspath(srcpath));
-		if (ret <= 0)
+		if (ret < 0)
 			return ERR_PTR(-ENOMEM);
 
 		ret = selabel_lookup(cfg.sehnd, &secontext, fspath, mode);


### PR DESCRIPTION
Signed-off-by: liujinbao1 <liujinbao1@xiaomi.com>