### PR TITLE
blobchunk: fix 48-bit chunk format detection to use final remapped addresses

### DIFF
--- a/lib/blobchunk.c
+++ b/lib/blobchunk.c
@@ -154,6 +154,19 @@ int erofs_write_chunk_indexes(struct erofs_inode *inode, struct erofs_vfile *vf,
 		unit = EROFS_BLOCK_MAP_ENTRY_SIZE;
 
 	chunkblks = 1ULL << (inode->u.chunkformat & EROFS_CHUNK_FORMAT_BLKBITS_MASK);
+
+	/* check if any chunk lands above 32-bit range once remapped_base is applied */
+	for (src = 0; src < inode->extent_isize / unit * sizeof(void *);
+	     src += sizeof(void *)) {
+		struct erofs_blobchunk *chunk = *(void **)(inode->chunkindexes + src);
+
+		if (chunk->blkaddr != EROFS_NULL_ADDR && !chunk->device_id &&
+		    remapped_base + chunk->blkaddr > UINT32_MAX) {
+			inode->u.chunkformat |= EROFS_CHUNK_FORMAT_48BIT;
+			break;
+		}
+	}
+
 	_48bit = inode->u.chunkformat & EROFS_CHUNK_FORMAT_48BIT;
 	for (dst = src = 0; dst < inode->extent_isize;
 	     src += sizeof(void *), dst += unit) {
@@ -380,10 +393,6 @@ int erofs_blob_write_chunked_file(struct erofs_inode *inode, int fd,
 			goto err;
 		}
 
-		/* FIXME! `chunk->blkaddr` is not the final blkaddr here */
-		if (chunk->blkaddr != EROFS_NULL_ADDR &&
-		    chunk->blkaddr >= UINT32_MAX)
-			inode->u.chunkformat |= EROFS_CHUNK_FORMAT_48BIT;
 		if (!erofs_blob_can_merge(sbi, lastch, chunk)) {
 			erofs_update_minextblks(sbi, interval_start, pos,
 						&minextblks);


### PR DESCRIPTION
The 48-bit format flag on chunk-based inodes was being set inside erofs_blob_write_chunked_file right after erofs_blob_getchunk returns. The problem is that at that point chunk->blkaddr is just the chunk's current seek position inside the blobfile, not the address it will actually land at in the final image. The real address only gets determined in erofs_mkfs_dump_blobs when remapped_base is computed and applied.

So the check was firing on an intermediate blob-relative offset that may or may not cross the 32-bit boundary, making the detection wrong in both directions. A chunk whose blob offset looks large but whose final remapped address fits in 32-bits would get flagged unnecessarily. Worse, a chunk that ends up above UINT32_MAX after remapping could slip through without the flag being set, which means the kernel reads the wrong block address out of a corrupt image.

The fix removes that early check entirely and adds a small pre-scan at the top of erofs_write_chunk_indexes, which runs after erofs_mkfs_dump_blobs has already set remapped_base. At that point we walk the chunk array and check if any remapped_base plus chunk->blkaddr exceeds UINT32_MAX, set EROFS_CHUNK_FORMAT_48BIT on the inode if so, and then the existing _48bit read below picks up the correct value for the rest of the function.

Confirmed the call order in mkfs/main.c: erofs_mkfs_dump_blobs is called at line 2097, erofs_importer_flush_all follows at line 2102, and erofs_write_chunk_indexes is only reached through the bflush pipeline inside that, so remapped_base is always set before the pre-scan runs.

fixes #39 